### PR TITLE
Fix unescaped ampersands in Google Fonts URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Talleres Santa Pola SL – Mecánica Integral</title>
-  <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700&family=Open+Sans:wght@400;600&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700&amp;family=Open+Sans:wght@400;600&amp;display=swap" rel="stylesheet">
   <link rel="stylesheet" href="style.css">
 </head>
 <body>


### PR DESCRIPTION
## Summary
- escape `&` characters in Google Fonts link to produce valid HTML

## Testing
- `tidy -q -e index.html`

------
https://chatgpt.com/codex/tasks/task_e_68930fe29bd48326a2b7c5754ee2eb3f